### PR TITLE
Round before handing off to `slice_sample()`

### DIFF
--- a/R/kms_cv.r
+++ b/R/kms_cv.r
@@ -83,7 +83,7 @@ kms_cv <- function(data,k = 5,centers = NULL,max_center = 20,alpha = .1,seed = N
         
        props <- current_prop_df[['Prop']]
         
-       group_size <- ideal_sample_size * props
+       group_size <- round(ideal_sample_size * props)
         
        resample <- purrr::map2_dfr(dplyr::group_split(dplyr::group_by_at(data_,'cls')),group_size, ~ dplyr::slice_sample(.x, n = .y))
         


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`slice_sample()` now requires that `n` is a whole number. I've chosen to enforce this here by using `round()`, but you might want a different approach.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!